### PR TITLE
Support reading from a configuration file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,29 +27,29 @@ Invoke one of the provided tasks:
 > openApiStyleValidationResult
 ```
 
-### Configuration
+## Configuration
 
 You may specify [openapi-style-validator](https://github.com/OpenAPITools/openapi-style-validator) settings either in a configuration file or directly in the sbt build definition using the provided keys.
 
-##### Using a configuration file
+### Using a configuration file
 
 Supported formats include Java properties, [HOCON](https://github.com/lightbend/config/blob/master/HOCON.md) and JSON.
 
 Specify the config file in `build.sbt`:
 ```sbt
-openApiStyleConfig := Some(file(".openapi-style-validator.conf"))
+openApiStyleConfig := Some(file("openapi-style-validator.conf"))
 ```
 
 Specify configurations in the config file:
 ```hocon
 validateNaming = true
-pathNamingConvention = false
+pathNamingConvention = UnderscoreCase
 // etc.
 ```
 
 Keys are the same as in [openapi-style-validator](https://github.com/OpenAPITools/openapi-style-validator).
 
-##### Directly in sbt
+### Directly in sbt
 
 You may also specify configuration settings directly in `build.sbt` via the provided keys:
 ```sbt
@@ -58,7 +58,7 @@ openApiStylePathNamingConvention := Some(NamingConvention.UnderscoreCase)
 // etc.
 ```
 
-# sbt keys
+## sbt keys
 
 | Key | Type | Description |
 | --- | ---- | ----------- |

--- a/README.md
+++ b/README.md
@@ -27,19 +27,51 @@ Invoke one of the provided tasks:
 > openApiStyleValidationResult
 ```
 
+### Configuration
+
+You may specify [openapi-style-validator](https://github.com/OpenAPITools/openapi-style-validator) settings either in a configuration file or directly in the sbt build definition using the provided keys.
+
+##### Using a configuration file
+
+Supported formats include Java properties, [HOCON](https://github.com/lightbend/config/blob/master/HOCON.md) and JSON.
+
+Specify the config file in `build.sbt`:
+```sbt
+openApiStyleConfig := Some(file(".openapi-style-validator.conf"))
+```
+
+Specify configurations in the config file:
+```hocon
+validateNaming = true
+pathNamingConvention = false
+// etc.
+```
+
+Keys are the same as in [openapi-style-validator](https://github.com/OpenAPITools/openapi-style-validator).
+
+##### Directly in sbt
+
+You may also specify configuration settings directly in `build.sbt` via the provided keys:
+```sbt
+openApiStyleValidateNaming := Some(true)
+openApiStylePathNamingConvention := Some(NamingConvention.UnderscoreCase)
+// etc.
+```
+
 # sbt keys
 
 | Key | Type | Description |
-| ------- | ---- | ----------- |
+| --- | ---- | ----------- |
+| `openApiStyleConfig` | `SettingKey[Option[File]]` | OpenAPI Style Validator configuration file. Defaults to `None`. |
 | `openApiStyleSpec` | `TaskKey[File]` | OpenAPI specification file. |
 | `openApiStyleValidate` | `TaskKey[Unit]` | Validates OpenAPI specification file: success or failure. |
 | `openApiStyleValidationResult` | `TaskKey[Seq[String]]` | Validates OpenAPI specification file: evaluates to a list of detailed error messages. |
-| `openApiStyleValidatorParameters` | `SettingKey[ValidatorParameters]` | OpenAPI Style Validator parameters. |
+| `openApiStyleValidatorParameters` | `SettingKey[ValidatorParameters]` | OpenAPI Style Validator parameters, typically set using configuration keys or a configuration file. |
 
-The following configurations are supported from [OpenAPI Style Validator](https://github.com/OpenAPITools/openapi-style-validator):
+The following configuration keys are supported:
 
 | Key | Type | Description |
-| ------- | ---- | ----------- |
+| --- | ---- | ----------- |
 | `openApiStyleValidateInfoLicense` | `SettingKey[Option[Boolean]]` | Ensures that there is a license section in the info section. |
 | `openApiStyleValidateInfoDescription` | `SettingKey[Option[Boolean]]` | Ensures that there is a description attribute in the info section. |
 | `openApiStyleValidateInfoContact` | `SettingKey[Option[Boolean]]` | Ensures that there is a contact section in the info section. |
@@ -49,7 +81,7 @@ The following configurations are supported from [OpenAPI Style Validator](https:
 | `openApiStyleValidateOperationSummary` | `SettingKey[Option[Boolean]]` | Ensures that there is a summary for each operation. |
 | `openApiStyleValidateModelPropertiesExample` | `SettingKey[Option[Boolean]]` | Ensures that the properties of the Schemas have an example value defined. |
 | `openApiStyleValidateNaming` | `SettingKey[Option[Boolean]]` | Ensures the names follow a given naming convention. |
-| `openApiStyleIgnoreHeaderXNaming` | `SettingKey[Option[Boolean]]` | Exclude from validation header parameters starting with x-. |
+| `openApiStyleIgnoreHeaderXNaming` | `SettingKey[Option[Boolean]]` | Exclude from validation header parameters starting with `x-`. |
 | `openApiStylePathNamingConvention` | `SettingKey[Option[NamingConvention]]` | Naming convention for paths. |
 | `openApiStyleParameterNamingConvention` | `SettingKey[Option[NamingConvention]]` | Naming convention for parameters. |
 | `openApiStyleHeaderNamingConvention` | `SettingKey[Option[NamingConvention]]` | Naming convention for headers. |

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,8 @@ crossSbtVersions := List("0.13.18", "1.4.6")
 libraryDependencies ++= Seq(
   "org.openapitools.openapistylevalidator" % "openapi-style-validator-lib" % "1.5",
   "io.swagger.parser.v3" % "swagger-parser" % "2.0.24",
-  "org.openapitools.empoa" % "empoa-swagger-core" % "2.0.0"
+  "org.openapitools.empoa" % "empoa-swagger-core" % "2.0.0",
+  "com.typesafe" % "config" % "1.4.1"
 )
 
 publishMavenStyle := false

--- a/src/main/scala/org/openapitools/openapistylevalidator/sbt/plugin/OpenApiStyleKeys.scala
+++ b/src/main/scala/org/openapitools/openapistylevalidator/sbt/plugin/OpenApiStyleKeys.scala
@@ -6,6 +6,7 @@ import sbt._
 
 trait OpenApiStyleKeys {
 
+  final val openApiStyleConfig = settingKey[Option[File]]("OpenAPI Style Validator configuration file.")
   final val openApiStyleSpec = taskKey[File]("OpenAPI specification file.")
   final val openApiStyleValidate = taskKey[Unit]("Validates OpenAPI specification file: success or failure.")
   final val openApiStyleValidationResult = taskKey[Seq[String]]("Validates OpenAPI specification file: evaluates to a list of detailed error messages.")

--- a/src/main/scala/org/openapitools/openapistylevalidator/sbt/plugin/config/ConfigExtension.scala
+++ b/src/main/scala/org/openapitools/openapistylevalidator/sbt/plugin/config/ConfigExtension.scala
@@ -1,0 +1,25 @@
+package org.openapitools.openapistylevalidator.sbt.plugin.config
+
+import com.typesafe.config.Config
+
+private[plugin] object ConfigExtension {
+
+  implicit class RichConfig(val underlying: Config) extends AnyVal {
+    def getOptionalBoolean(path: String): Option[Boolean] = {
+      if (underlying.hasPath(path)) {
+        Some(underlying.getBoolean(path))
+      } else {
+        None
+      }
+    }
+
+    def getOptionalString(path: String): Option[String] = {
+      if (underlying.hasPath(path)) {
+        Some(underlying.getString(path))
+      } else {
+        None
+      }
+    }
+  }
+
+}

--- a/src/main/scala/org/openapitools/openapistylevalidator/sbt/plugin/tasks/OpenApiStyleValidateTask.scala
+++ b/src/main/scala/org/openapitools/openapistylevalidator/sbt/plugin/tasks/OpenApiStyleValidateTask.scala
@@ -1,0 +1,19 @@
+package org.openapitools.openapistylevalidator.sbt.plugin.tasks
+
+import org.openapitools.openapistylevalidator.sbt.plugin.OpenApiStyleKeys
+import sbt.Keys._
+import sbt.{Def, Task}
+
+trait OpenApiStyleValidateTask extends OpenApiStyleKeys {
+
+  def openApiStyleValidateTask(): Def.Initialize[Task[Unit]] = Def.task {
+    val log = streams.value.log
+    val errors = openApiStyleValidationResult.value
+
+    if (errors.nonEmpty) {
+      val report = errors.mkString("\n")
+      sys.error("OpenAPI specification style validation failed.\n" + report)
+    } else log.info("OpenAPI specification style validation passed.")
+  }
+
+}

--- a/src/main/scala/org/openapitools/openapistylevalidator/sbt/plugin/tasks/OpenApiStyleValidationResultTask.scala
+++ b/src/main/scala/org/openapitools/openapistylevalidator/sbt/plugin/tasks/OpenApiStyleValidationResultTask.scala
@@ -1,0 +1,31 @@
+package org.openapitools.openapistylevalidator.sbt.plugin.tasks
+
+import io.swagger.v3.parser.OpenAPIV3Parser
+import org.openapitools.empoa.swagger.core.internal.SwAdapter
+import org.openapitools.openapistylevalidator.OpenApiSpecStyleValidator
+import org.openapitools.openapistylevalidator.sbt.plugin.OpenApiStyleKeys
+import org.openapitools.openapistylevalidator.styleerror.StyleError
+import sbt.{Def, Task}
+
+import java.util.function.Consumer
+import scala.collection.mutable.ListBuffer
+
+trait OpenApiStyleValidationResultTask extends OpenApiStyleKeys {
+
+  def openApiStyleValidationResultTask(): Def.Initialize[Task[List[String]]] = Def.task {
+    val parameters = openApiStyleValidatorParameters.value
+
+    val swaggerOpenApiParser = new OpenAPIV3Parser()
+    val swaggerOpenApi = swaggerOpenApiParser.read(openApiStyleSpec.value.getAbsolutePath)
+
+    val openApi = SwAdapter.toOpenAPI(swaggerOpenApi)
+    val validator = new OpenApiSpecStyleValidator(openApi)
+
+    val errors = ListBuffer.empty[String]
+    validator.validate(parameters).forEach(new Consumer[StyleError] {
+      override def accept(error: StyleError): Unit = errors += error.toString
+    })
+    errors.toList
+  }
+
+}

--- a/src/main/scala/org/openapitools/openapistylevalidator/sbt/plugin/tasks/OpenApiStyleValidatorParametersTask.scala
+++ b/src/main/scala/org/openapitools/openapistylevalidator/sbt/plugin/tasks/OpenApiStyleValidatorParametersTask.scala
@@ -1,7 +1,10 @@
 package org.openapitools.openapistylevalidator.sbt.plugin.tasks
 
+import com.typesafe.config.ConfigFactory
 import org.openapitools.openapistylevalidator.ValidatorParameters
+import org.openapitools.openapistylevalidator.ValidatorParameters.NamingConvention
 import org.openapitools.openapistylevalidator.sbt.plugin.OpenApiStyleKeys
+import org.openapitools.openapistylevalidator.sbt.plugin.config.ConfigExtension._
 import sbt._
 
 trait OpenApiStyleValidatorParametersTask extends OpenApiStyleKeys {
@@ -9,61 +12,89 @@ trait OpenApiStyleValidatorParametersTask extends OpenApiStyleKeys {
   def openApiStyleValidatorParametersTask(): Def.Initialize[ValidatorParameters] = Def.setting {
     val parameters = new ValidatorParameters()
 
-    openApiStyleValidateInfoLicense.value.foreach { setting =>
-      parameters.setValidateInfoLicense(setting)
+    openApiStyleConfig.value.foreach { file =>
+      val config = ConfigFactory.parseFile(file)
+
+      config
+        .getOptionalBoolean("validateInfoLicense")
+        .foreach(parameters.setValidateInfoLicense)
+
+      config
+        .getOptionalBoolean("validateInfoDescription")
+        .foreach(parameters.setValidateInfoDescription)
+
+      config
+        .getOptionalBoolean("validateInfoContact")
+        .foreach(parameters.setValidateInfoContact)
+
+      config
+        .getOptionalBoolean("validateOperationId")
+        .foreach(parameters.setValidateOperationOperationId)
+
+      config
+        .getOptionalBoolean("validateOperationDescription")
+        .foreach(parameters.setValidateOperationDescription)
+
+      config
+        .getOptionalBoolean("validateOperationTag")
+        .foreach(parameters.setValidateOperationTag)
+
+      config
+        .getOptionalBoolean("validateOperationSummary")
+        .foreach(parameters.setValidateOperationSummary)
+
+      config
+        .getOptionalBoolean("validateModelPropertiesExample")
+        .foreach(parameters.setValidateModelPropertiesExample)
+
+      config
+        .getOptionalBoolean("validateNaming")
+        .foreach(parameters.setValidateNaming)
+
+      config
+        .getOptionalBoolean("ignoreHeaderXNaming")
+        .foreach(parameters.setIgnoreHeaderXNaming)
+
+      config
+        .getOptionalString("pathNamingConvention")
+        .map(NamingConvention.valueOf)
+        .foreach(parameters.setPathNamingConvention)
+
+      config
+        .getOptionalString("parameterNamingConvention")
+        .map(NamingConvention.valueOf)
+        .foreach(parameters.setParameterNamingConvention)
+
+      config
+        .getOptionalString("headerNamingConvention")
+        .map(NamingConvention.valueOf)
+        .foreach(parameters.setHeaderNamingConvention)
+
+      config
+        .getOptionalString("propertyNamingConvention")
+        .map(NamingConvention.valueOf)
+        .foreach(parameters.setPropertyNamingConvention)
     }
 
-    openApiStyleValidateInfoDescription.value.foreach { setting =>
-      parameters.setValidateInfoDescription(setting)
-    }
+    openApiStyleValidateInfoLicense.value.foreach(parameters.setValidateInfoLicense)
+    openApiStyleValidateInfoDescription.value.foreach(parameters.setValidateInfoDescription)
+    openApiStyleValidateInfoContact.value.foreach(parameters.setValidateInfoContact)
 
-    openApiStyleValidateInfoContact.value.foreach { setting =>
-      parameters.setValidateInfoContact(setting)
-    }
+    openApiStyleValidateOperationId.value.foreach(parameters.setValidateOperationOperationId)
+    openApiStyleValidateOperationDescription.value.foreach(parameters.setValidateOperationDescription)
+    openApiStyleValidateOperationTag.value.foreach(parameters.setValidateOperationTag)
+    openApiStyleValidateOperationSummary.value.foreach(parameters.setValidateOperationSummary)
 
-    openApiStyleValidateOperationId.value.foreach { setting =>
-      parameters.setValidateOperationOperationId(setting)
-    }
+    openApiStyleValidateModelPropertiesExample.value.foreach(parameters.setValidateModelPropertiesExample)
 
-    openApiStyleValidateOperationDescription.value.foreach { setting =>
-      parameters.setValidateOperationDescription(setting)
-    }
+    openApiStyleValidateNaming.value.foreach(parameters.setValidateNaming)
 
-    openApiStyleValidateOperationTag.value.foreach { setting =>
-      parameters.setValidateOperationTag(setting)
-    }
+    openApiStyleIgnoreHeaderXNaming.value.foreach(parameters.setIgnoreHeaderXNaming)
 
-    openApiStyleValidateOperationSummary.value.foreach { setting =>
-      parameters.setValidateOperationSummary(setting)
-    }
-
-    openApiStyleValidateModelPropertiesExample.value.foreach { setting =>
-      parameters.setValidateModelPropertiesExample(setting)
-    }
-
-    openApiStyleValidateNaming.value.foreach { setting =>
-      parameters.setValidateNaming(setting)
-    }
-
-    openApiStyleIgnoreHeaderXNaming.value.foreach { setting =>
-      parameters.setIgnoreHeaderXNaming(setting)
-    }
-
-    openApiStylePathNamingConvention.value.foreach { setting =>
-      parameters.setPathNamingConvention(setting)
-    }
-
-    openApiStyleParameterNamingConvention.value.foreach { setting =>
-      parameters.setParameterNamingConvention(setting)
-    }
-
-    openApiStyleHeaderNamingConvention.value.foreach { setting =>
-      parameters.setHeaderNamingConvention(setting)
-    }
-
-    openApiStylePropertyNamingConvention.value.foreach { setting =>
-      parameters.setParameterNamingConvention(setting)
-    }
+    openApiStylePathNamingConvention.value.foreach(parameters.setPathNamingConvention)
+    openApiStyleParameterNamingConvention.value.foreach(parameters.setParameterNamingConvention)
+    openApiStyleHeaderNamingConvention.value.foreach(parameters.setHeaderNamingConvention)
+    openApiStylePropertyNamingConvention.value.foreach(parameters.setParameterNamingConvention)
 
     parameters
   }

--- a/src/sbt-test/sbt-openapi-style-validator/simple/build.sbt
+++ b/src/sbt-test/sbt-openapi-style-validator/simple/build.sbt
@@ -1,5 +1,19 @@
 lazy val noop = project
 
+lazy val config = project
+  .enablePlugins(OpenApiStylePlugin)
+  .settings(
+    openApiStyleSpec := file("petstore.yaml"),
+    openApiStyleConfig := Some(file("openapi-style-validator.conf"))
+  )
+  .settings(
+    TaskKey[Unit]("check") := {
+      val errors = openApiStyleValidationResult.value
+      if (errors.nonEmpty) sys.error("Style validation errors found.")
+      ()
+    }
+  )
+
 lazy val problematic = project
   .enablePlugins(OpenApiStylePlugin)
   .settings(openApiStyleSpec := file("petstore.yaml"))

--- a/src/sbt-test/sbt-openapi-style-validator/simple/openapi-style-validator.conf
+++ b/src/sbt-test/sbt-openapi-style-validator/simple/openapi-style-validator.conf
@@ -1,0 +1,14 @@
+validateInfoLicense = false
+validateInfoDescription = false
+validateInfoContact = false
+
+validateOperationId = false
+validateOperationDescription = false
+validateOperationTag = false
+validateOperationSummary = false
+
+validateModelPropertiesExample = false
+
+validateNaming = false
+
+ignoreHeaderXNaming = false

--- a/src/sbt-test/sbt-openapi-style-validator/simple/openapi-style-validator.conf
+++ b/src/sbt-test/sbt-openapi-style-validator/simple/openapi-style-validator.conf
@@ -12,3 +12,8 @@ validateModelPropertiesExample = false
 validateNaming = false
 
 ignoreHeaderXNaming = false
+
+pathNamingConvention = UnderscoreCase
+parameterNamingConvention = UnderscoreUpperCase
+headerNamingConvention = CamelCase
+propertyNamingConvention = HyphenCase

--- a/src/sbt-test/sbt-openapi-style-validator/simple/test
+++ b/src/sbt-test/sbt-openapi-style-validator/simple/test
@@ -4,5 +4,6 @@
 
 -> openApiStyleValidate
 
+> config/check
 > problematic/check
 > ok/check


### PR DESCRIPTION
* Split remaining task definitions into `trait`s in the `task` package.
* Use [Typesafe config](https://github.com/lightbend/config) to read configurations from config files. Supports json, hocon, and java properties.

@JFCote 